### PR TITLE
fix(gulps): Update gulp-sass version as 2.0.1 fails to install

### DIFF
--- a/gulps/index.js
+++ b/gulps/index.js
@@ -83,7 +83,7 @@ var GulpsGenerator = yeoman.generators.Base.extend({
             'gulp-plumber': '1.0.1',
             'gulp-protractor': '0.0.12',
             'gulp-rename': '1.2.2',
-            'gulp-sass': '2.0.1',
+            'gulp-sass': '2.0.3',
             'gulp-size': '1.2.1',
             'gulp-sourcemaps': '1.5.2',
             'gulp-tap': '0.1.3',


### PR DESCRIPTION
Hello,

I've had an issue installing gulp-sass 2.0.1 (`npm ERR! version not found: gulp-sass@2.0.1`), so I had to change version to the latest one. That solved the problem.