### PR TITLE
Fix gulp-sass version

### DIFF
--- a/gulps/index.js
+++ b/gulps/index.js
@@ -83,7 +83,7 @@ var GulpsGenerator = yeoman.generators.Base.extend({
             'gulp-plumber': '1.0.1',
             'gulp-protractor': '0.0.12',
             'gulp-rename': '1.2.2',
-            'gulp-sass': '2.0.1',
+            'gulp-sass': '2.0.3',
             'gulp-size': '1.2.1',
             'gulp-sourcemaps': '1.5.2',
             'gulp-tap': '0.1.3',


### PR DESCRIPTION
gulp-sass version 2.0.1 doesn't longer exist.

npm ERR! node v0.12.2
npm ERR! npm  v2.12.0

npm ERR! version not found: gulp-sass@2.0.1
npm ERR! 
npm ERR! If you need help, you may report this error at:
npm ERR!     <https://github.com/npm/npm/issues>

npm ERR! Please include the following file with any support request:
npm ERR!     /home/alexandre/dev/extern/generator-mcfly/npm-debug.log
events.js:87
      throw Error('Uncaught, unspecified "error" event.');
