### PR TITLE
fix(gulps): updated transform-loader dependency to work with node.js 4.x

### DIFF
--- a/gulps/index.js
+++ b/gulps/index.js
@@ -146,7 +146,7 @@ var GulpsGenerator = yeoman.generators.Base.extend({
             'stream-combiner': '0.2.2',
             //'streamqueue': '1.1.0',
             'strip-json-comments': '1.0.2',
-            'transform-loader': '0.2.2',
+            'transform-loader': '0.2.3',
             'uglifyify': '3.0.1',
             'vinyl-buffer': '1.0.0',
             'vinyl-source-stream': '1.1.0',


### PR DESCRIPTION
Updated the transform-loader dependency for webpack to 0.2.3 - 0.2.2 created a bug with the node buffer module. 

    buffer.js:219
        buf.copy(buffer, pos);
            ^

    TypeError: buf.copy is not a function
        at Function.Buffer.concat (buffer.js:219:9)
        at Stream.<anonymous> (/Users/ferdinand/Code/bridge-webapp/node_modules/transform-loader/index.js:33:19)